### PR TITLE
Fix search partitions listing to include NVME

### DIFF
--- a/mhwd-chroot-shell
+++ b/mhwd-chroot-shell
@@ -23,7 +23,7 @@ list=()
 nbpart=0
 
 # Search for partitions containing /etc
-for i in $(ls /dev/[hs]d[a-z][1-9]* || ls /dev/nvme[0-9][a-z][0-9][a-z][0-9]*)
+for i in $(ls /dev/[hs]d[a-z][1-9]* && ls /dev/nvme[0-9][a-z][0-9][a-z][0-9]*)
 do
     [ $i = "$curetc" ] && continue
     mount $i $mountpoint 2>/dev/null


### PR DESCRIPTION
I discovered this while attempting to chroot to an NVME drive, code has been tested and fixes the logic issue.